### PR TITLE
Move away from using KeyValuePair for entry storage.

### DIFF
--- a/CacheTable/ConcurrentCacheTable.cs
+++ b/CacheTable/ConcurrentCacheTable.cs
@@ -175,9 +175,9 @@ namespace CacheTable
                         (int rowStart, int rowEnd) = this.table.GetRowRange(row);
                         for (int i = rowStart; i < rowEnd; i++)
                         {
-                            if (this.table.table[i].HasValue)
+                            if (this.table.table[i].IsSet)
                             {
-                                yield return this.table.table[i].Value;
+                                yield return this.table.table[i].CreateKvp();
                             }
                         }
                     }


### PR DESCRIPTION
Benchmarks run on:

``` ini

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17763.316 (1809/October2018Update/Redstone5)
Intel Core i9-9900K CPU 3.60GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=2.1.504
  [Host] : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT
  Core   : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT

Job=Core  Runtime=Core  

```
# SetSingleItem

## Before

|               Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Rank |
|--------------------- |-----------:|----------:|----------:|------:|--------:|-----:|
|           CacheTable | 17.3135 ns | 0.0205 ns | 0.0181 ns | 3.432 |    0.01 |    3 |
| ConcurrentCacheTable | 38.2566 ns | 0.0692 ns | 0.0614 ns | 7.583 |    0.02 |    5 |
|           Dictionary |  5.0449 ns | 0.0174 ns | 0.0154 ns | 1.000 |    0.00 |    2 |
| ConcurrentDictionary | 28.4257 ns | 0.0954 ns | 0.0846 ns | 5.635 |    0.02 |    4 |
|                Array |  0.0320 ns | 0.0022 ns | 0.0020 ns | 0.006 |    0.00 |    1 |

## After

|               Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Rank |
|--------------------- |-----------:|----------:|----------:|------:|--------:|-----:|
|           CacheTable | 12.8624 ns | 0.0270 ns | 0.0211 ns | 2.554 |    0.01 |    3 |
| ConcurrentCacheTable | 34.0698 ns | 0.2655 ns | 0.2483 ns | 6.775 |    0.05 |    5 |
|           Dictionary |  5.0376 ns | 0.0101 ns | 0.0084 ns | 1.000 |    0.00 |    2 |
| ConcurrentDictionary | 28.5702 ns | 0.0327 ns | 0.0290 ns | 5.671 |    0.01 |    4 |
|                Array |  0.0281 ns | 0.0016 ns | 0.0014 ns | 0.006 |    0.00 |    1 |

# ReadItemExists

## Before

|               Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Rank |
|--------------------- |-----------:|----------:|----------:|------:|--------:|-----:|
|           CacheTable | 21.4661 ns | 0.1197 ns | 0.1120 ns |  4.65 |    0.03 |    4 |
| ConcurrentCacheTable | 37.9830 ns | 0.0551 ns | 0.0516 ns |  8.24 |    0.01 |    5 |
|           Dictionary |  4.6125 ns | 0.0062 ns | 0.0051 ns |  1.00 |    0.00 |    2 |
| ConcurrentDictionary |  8.0561 ns | 0.0140 ns | 0.0117 ns |  1.75 |    0.00 |    3 |
|                Array |  0.1033 ns | 0.0051 ns | 0.0046 ns |  0.02 |    0.00 |    1 |

## After

|               Method |       Mean |     Error |    StdDev | Ratio | Rank |
|--------------------- |-----------:|----------:|----------:|------:|-----:|
|           CacheTable | 12.0253 ns | 0.0640 ns | 0.0599 ns | 2.615 |    4 |
| ConcurrentCacheTable | 33.3455 ns | 0.0503 ns | 0.0446 ns | 7.253 |    5 |
|           Dictionary |  4.5977 ns | 0.0051 ns | 0.0045 ns | 1.000 |    2 |
| ConcurrentDictionary |  7.9392 ns | 0.0287 ns | 0.0224 ns | 1.727 |    3 |
|                Array |  0.0083 ns | 0.0026 ns | 0.0024 ns | 0.002 |    1 |

# ReadItemNotExists

## Before

|               Method |       Mean |     Error |    StdDev |  Ratio | RatioSD | Rank |
|--------------------- |-----------:|----------:|----------:|-------:|--------:|-----:|
|           CacheTable | 16.2372 ns | 0.0131 ns | 0.0116 ns |  8.954 |    0.05 |    4 |
| ConcurrentCacheTable | 32.5453 ns | 0.0420 ns | 0.0393 ns | 17.944 |    0.12 |    5 |
|           Dictionary |  1.8136 ns | 0.0121 ns | 0.0101 ns |  1.000 |    0.00 |    2 |
| ConcurrentDictionary |  6.0299 ns | 0.0141 ns | 0.0132 ns |  3.324 |    0.02 |    3 |
|                Array |  0.0116 ns | 0.0014 ns | 0.0013 ns |  0.006 |    0.00 |    1 |

## After

|               Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Rank |
|--------------------- |-----------:|----------:|----------:|------:|--------:|-----:|
|           CacheTable | 11.1373 ns | 0.0160 ns | 0.0141 ns |  6.18 |    0.04 |    4 |
| ConcurrentCacheTable | 31.9135 ns | 0.0737 ns | 0.0654 ns | 17.70 |    0.12 |    5 |
|           Dictionary |  1.8036 ns | 0.0122 ns | 0.0115 ns |  1.00 |    0.00 |    2 |
| ConcurrentDictionary |  6.2468 ns | 0.0079 ns | 0.0070 ns |  3.47 |    0.02 |    3 |
|                Array |  0.0972 ns | 0.0058 ns | 0.0051 ns |  0.05 |    0.00 |    1 |
