### PR TITLE
Replace System.Random with Xorshift RNG.

### DIFF
--- a/Benchmark/Eviction.cs
+++ b/Benchmark/Eviction.cs
@@ -1,0 +1,35 @@
+﻿using BenchmarkDotNet.Attributes;
+using CacheTable;
+
+namespace Benchmark
+{
+    [ClrJob]
+    [RankColumn]
+    public class Eviction
+    {
+        private CacheTable<WrappedInt, int> cacheTable;
+        private int i;
+
+        [Params(4, 8)]
+        public int N;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.cacheTable = new CacheTable<WrappedInt, int>(10, this.N);
+
+            for (int i = 0; i < this.N; i++)
+            {
+                this.cacheTable[i] = i;
+            }
+
+            this.i = this.N;
+        }
+
+        [Benchmark]
+        public void CacheTable()
+        {
+            this.cacheTable[this.i] = this.i++;
+        }
+    }
+}

--- a/Benchmark/GuidKeysReadFullTable.cs
+++ b/Benchmark/GuidKeysReadFullTable.cs
@@ -1,0 +1,86 @@
+﻿using CacheTable;
+using System;
+using BenchmarkDotNet.Attributes;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace Benchmark
+{
+    [CoreJob]
+    [RPlotExporter, RankColumn]
+    public class GuidKeysReadFullTable
+    {
+        private readonly CacheTable<WrappedString, int> cacheTable = new CacheTable<WrappedString, int>(10, 4);
+        private readonly Dictionary<WrappedString, int> dictionary = new Dictionary<WrappedString, int>();
+        private WrappedString[] keys;
+
+        struct WrappedString : IEquatable<WrappedString>
+        {
+            public string Value;
+
+            public bool Equals(WrappedString other) => this.Value.Equals(other.Value);
+
+            public override int GetHashCode() => this.Value.GetHashCode();
+
+            public override bool Equals(object obj) => this.Equals((WrappedString)obj);
+
+            public static implicit operator WrappedString(string str) => new WrappedString { Value = str };
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            while (cacheTable.Count != 40)
+            {
+                this.cacheTable[Guid.NewGuid().ToString()] = 42;
+            }
+
+            this.keys = new WrappedString[40];
+            int i = 0;
+            foreach (KeyValuePair<WrappedString, int> kvp in cacheTable)
+            {
+                this.dictionary[kvp.Key] = kvp.Value;
+                this.keys[i++] = kvp.Key;
+            }
+
+            Random rng = new Random();
+            Shuffle(rng, this.keys);
+        }
+
+        public static void Shuffle<T>(Random rng, T[] array)
+        {
+            int n = array.Length;
+            while (n > 1)
+            {
+                int k = rng.Next(n--);
+                T temp = array[n];
+                array[n] = array[k];
+                array[k] = temp;
+            }
+        }
+
+        [Benchmark]
+        public int CacheTable()
+        {
+            int sum = 0;
+            foreach (var k in this.keys)
+            {
+                sum += this.cacheTable[k];
+            }
+
+            return sum;
+        }
+
+        [Benchmark(Baseline = true)]
+        public int Dictionary()
+        {
+            int sum = 0;
+            foreach (var k in this.keys)
+            {
+                sum += this.dictionary[k];
+            }
+
+            return sum;
+        }
+    }
+}

--- a/Benchmark/HashCollisions.cs
+++ b/Benchmark/HashCollisions.cs
@@ -15,41 +15,31 @@ namespace Benchmark
         private readonly Dictionary<WrappedInt, int> dictionary = new Dictionary<WrappedInt, int>();
         private readonly ConcurrentDictionary<WrappedInt, int> concurrentDictionary = new ConcurrentDictionary<WrappedInt, int>();
 
-        struct WrappedInt : IEquatable<WrappedInt>
-        {
-            public int Value;
-
-            public bool Equals(WrappedInt other) => this.Value == other.Value;
-
-            public override int GetHashCode() => 42;
-
-            public override bool Equals(object obj) => this.Equals((WrappedInt)obj);
-
-            public static implicit operator WrappedInt(int i) => new WrappedInt { Value = i };
-        }
+        [Params(32, 64)]
+        public int N;
 
         [Benchmark]
         public void CacheTable()
         {
-            for (int i = 0; i < 4; i++) this.cacheTable[i] = i;
-        }
-
-        [Benchmark]
-        public void ConcurrentCacheTable()
-        {
-            for (int i = 0; i < 4; i++) this.concurrentCacheTable[i] = i;
+            for (int i = 0; i < this.N; i++) this.cacheTable[i] = i;
         }
 
         [Benchmark(Baseline = true)]
         public void Dictionary()
         {
-            for (int i = 0; i < 4; i++) this.dictionary[i] = i;
+            for (int i = 0; i < this.N; i++) this.dictionary[i] = i;
+        }
+
+        [Benchmark]
+        public void ConcurrentCacheTable()
+        {
+            for (int i = 0; i < this.N; i++) this.concurrentCacheTable[i] = i;
         }
 
         [Benchmark]
         public void ConcurrentDictionary()
         {
-            for (int i = 0; i < 4; i++) this.concurrentDictionary[i] = i;
+            for (int i = 0; i < this.N; i++) this.concurrentDictionary[i] = i;
         }
     }
 }

--- a/Benchmark/RngPerf.cs
+++ b/Benchmark/RngPerf.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Attributes;
+using CacheTable;
+using System;
+
+namespace Benchmark
+{
+    [CoreJob]
+    [RankColumn]
+    public class RngPerf
+    {
+        private readonly Random random = new Random();
+        private readonly XorShiftRandom xorshift = new XorShiftRandom();
+        
+        [Benchmark(Baseline = true)]
+        public int Random()
+        {
+            return this.random.Next(12);
+        }
+
+        [Benchmark]
+        public int XortShiftRandom()
+        {
+            return this.xorshift.Next(12);
+        }
+    }
+}

--- a/Benchmark/WrappedInt.cs
+++ b/Benchmark/WrappedInt.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Benchmark
+{
+    struct WrappedInt : IEquatable<WrappedInt>
+    {
+        public int Value;
+
+        public bool Equals(WrappedInt other) => this.Value == other.Value;
+
+        public override int GetHashCode() => 42;
+
+        public override bool Equals(object obj) => this.Equals((WrappedInt)obj);
+
+        public static implicit operator WrappedInt(int i) => new WrappedInt { Value = i };
+    }
+}

--- a/CacheTable/CacheTable.cs
+++ b/CacheTable/CacheTable.cs
@@ -14,7 +14,7 @@ namespace CacheTable
     {
         private CacheTableInternal<TKey, TValue> table;
         private int count;
-        private readonly Random rng = new Random();
+        private readonly XorShiftRandom rng = new XorShiftRandom();
 
         /// <summary>
         /// Creates a set associative cache with specified number of rows and columns.

--- a/CacheTable/CacheTableInternal.cs
+++ b/CacheTable/CacheTableInternal.cs
@@ -106,7 +106,7 @@ namespace CacheTable
         }
 
         // Returns true if item was inserted into empty slot. False otherwise.
-        public bool Set(TKey key, TValue value, int row, Random rng)
+        public bool Set(TKey key, TValue value, int row, XorShiftRandom rng)
         {
             (int rowStart, int rowEnd) = this.GetRowRange(row);
             int empty = -1;

--- a/CacheTable/ConcurrentCacheTable.cs
+++ b/CacheTable/ConcurrentCacheTable.cs
@@ -15,7 +15,7 @@ namespace CacheTable
     {
         private readonly CacheTableInternal<TKey, TValue> table;
         private readonly object[] lockObjects;
-        private readonly Random[] rngs;
+        private readonly XorShiftRandom[] rngs;
         private readonly int[] counts;
 
         /// <summary>
@@ -35,10 +35,10 @@ namespace CacheTable
                 this.lockObjects[i] = new object();
             }
 
-            this.rngs = new Random[concurrency];
+            this.rngs = new XorShiftRandom[concurrency];
             for (int i = 0; i < concurrency; i++)
             {
-                this.rngs[i] = new Random();
+                this.rngs[i] = new XorShiftRandom();
             }
         }
 
@@ -248,7 +248,7 @@ namespace CacheTable
             return this.lockObjects[row % this.lockObjects.Length];
         }
 
-        private Random GetRng(int row)
+        private XorShiftRandom GetRng(int row)
         {
             return this.rngs[row % this.rngs.Length];
         }

--- a/CacheTable/XorShiftRandom.cs
+++ b/CacheTable/XorShiftRandom.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace CacheTable
+{
+    public class XorShiftRandom
+    {
+        [ThreadStatic]
+        private static readonly Random seedRng = new Random();
+
+        private uint state;
+
+        public XorShiftRandom() : this(GetNonZeroSeed())
+        {
+        }
+
+        public XorShiftRandom(uint seed)
+        {
+            this.state = seed;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Next(int max)
+        {
+            uint x = this.state;
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            this.state = x;
+            return (int)(x % max);
+        }
+
+        private static uint GetNonZeroSeed()
+        {
+            while (true)
+            {
+                uint seed = (uint)seedRng.Next();
+                if (seed != 0)
+                {
+                    return seed;
+                }
+            }
+        }
+    }
+}

--- a/CacheTable/XorShiftRandom.cs
+++ b/CacheTable/XorShiftRandom.cs
@@ -6,7 +6,7 @@ namespace CacheTable
     public class XorShiftRandom
     {
         [ThreadStatic]
-        private static readonly Random seedRng = new Random();
+        private static Random seedRng;
 
         private uint state;
 
@@ -32,6 +32,11 @@ namespace CacheTable
 
         private static uint GetNonZeroSeed()
         {
+            if (seedRng == null)
+            {
+                seedRng = new Random();
+            }
+
             while (true)
             {
                 uint seed = (uint)seedRng.Next();


### PR DESCRIPTION
A good chunk of time was spent in System.Random when we had to do evictions. Swapping out System.Random with a Xorshift RNG.

https://en.wikipedia.org/wiki/Xorshift

RngPerf benchmark shows Xorshift is quite a bit faster.

``` ini

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17763.316 (1809/October2018Update/Redstone5)
Intel Core i9-9900K CPU 3.60GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=2.1.504
  [Host] : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT
  Core   : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT

Job=Core  Runtime=Core  

```
|          Method |     Mean |     Error |    StdDev | Ratio | Rank |
|---------------- |---------:|----------:|----------:|------:|-----:|
|          Random | 8.779 ns | 0.1190 ns | 0.1113 ns |  1.00 |    2 |
| XortShiftRandom | 1.116 ns | 0.0069 ns | 0.0064 ns |  0.13 |    1 |

Also better performance in HashCollision benchmark which forces evictions.

**Before**

|     Method |  N |       Mean |    Error |   StdDev | Rank |
|----------- |--- |-----------:|---------:|---------:|-----:|
| **CacheTable** | **32** |   **950.3 ns** | **2.011 ns** | **1.570 ns** |    **1** |
| **CacheTable** | **64** | **1,876.8 ns** | **4.252 ns** | **3.769 ns** |    **2** |


**After**

|     Method |  N |       Mean |    Error |   StdDev | Rank |
|----------- |--- |-----------:|---------:|---------:|-----:|
| **CacheTable** | **32** |   **883.7 ns** | **2.390 ns** | **2.235 ns** |    **1** |
| **CacheTable** | **64** | **1,740.6 ns** | **8.394 ns** | **7.852 ns** |    **2** |
