### PR TITLE
Inline CacheTableInternal methods

### DIFF
--- a/CacheTable/CacheTableInternal.cs
+++ b/CacheTable/CacheTableInternal.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace CacheTable
 {
@@ -10,6 +11,7 @@ namespace CacheTable
         public V Value { get; set; }
         public bool IsSet { get; set; }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Clear()
         {
             this.Key = default(K);
@@ -17,6 +19,7 @@ namespace CacheTable
             this.IsSet = false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public KeyValuePair<K, V> CreateKvp() => new KeyValuePair<K, V>(this.Key, this.Value);
     }
 
@@ -33,6 +36,7 @@ namespace CacheTable
             this.table = new Entry<TKey, TValue>[numRows * numColumns];
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Clear()
         {
             for (int i = 0; i < this.table.Length; i++)
@@ -41,12 +45,14 @@ namespace CacheTable
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int FindRow(TKey key)
         {
             int hash = key.GetHashCode() & 0x7FFFFFFF;
             return hash % this.numRows;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public (int start, int end) GetRowRange(int row)
         {
             int start = row * this.numColumns;
@@ -54,6 +60,7 @@ namespace CacheTable
             return (start, end);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int FindEntry(TKey key, int row)
         {
             (int rowStart, int rowEnd) = this.GetRowRange(row);
@@ -68,6 +75,7 @@ namespace CacheTable
             return -1;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(TKey key, int row, out TValue value)
         {
             int loc = this.FindEntry(key, row);
@@ -82,6 +90,7 @@ namespace CacheTable
             return false;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Remove(TKey key, int row)
         {
             int loc = this.FindEntry(key, row);
@@ -94,6 +103,7 @@ namespace CacheTable
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
         {
             for (int i = 0; i < this.table.Length; i++)
@@ -106,6 +116,7 @@ namespace CacheTable
         }
 
         // Returns true if item was inserted into empty slot. False otherwise.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Set(TKey key, TValue value, int row, XorShiftRandom rng)
         {
             (int rowStart, int rowEnd) = this.GetRowRange(row);


### PR DESCRIPTION
Small perf improvement.

``` ini

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17763.316 (1809/October2018Update/Redstone5)
Intel Core i9-9900K CPU 3.60GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=2.1.504
  [Host] : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT
  Core   : .NET Core 2.1.8 (CoreCLR 4.6.27317.03, CoreFX 4.6.27317.03), 64bit RyuJIT

Job=Core  Runtime=Core  

```

# SetSingleInt

**Before**

|               Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Rank |
|--------------------- |-----------:|----------:|----------:|------:|--------:|-----:|
|           CacheTable | 13.2255 ns | 0.0205 ns | 0.0192 ns | 1.984 |    0.01 |    3 |
| ConcurrentCacheTable | 33.7917 ns | 0.3080 ns | 0.2881 ns | 5.068 |    0.05 |    5 |
|           Dictionary |  6.6678 ns | 0.0169 ns | 0.0158 ns | 1.000 |    0.00 |    2 |
| ConcurrentDictionary | 30.1072 ns | 0.1159 ns | 0.1084 ns | 4.515 |    0.02 |    4 |
|                Array |  0.0223 ns | 0.0027 ns | 0.0024 ns | 0.003 |    0.00 |    1 |

**After**

|               Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Rank |
|--------------------- |-----------:|----------:|----------:|------:|--------:|-----:|
|           CacheTable | 11.8372 ns | 0.0387 ns | 0.0362 ns | 2.261 |    0.01 |    3 |
| ConcurrentCacheTable | 27.4407 ns | 0.0329 ns | 0.0308 ns | 5.244 |    0.01 |    4 |
|           Dictionary |  5.2329 ns | 0.0152 ns | 0.0134 ns | 1.000 |    0.00 |    2 |
| ConcurrentDictionary | 28.6915 ns | 0.0751 ns | 0.0703 ns | 5.482 |    0.02 |    5 |
|                Array |  0.0081 ns | 0.0042 ns | 0.0040 ns | 0.002 |    0.00 |    1 |


# SetSingleString

**Before**

|               Method |      Mean |     Error |    StdDev | Ratio | RatioSD | Rank |
|--------------------- |----------:|----------:|----------:|------:|--------:|-----:|
|           CacheTable | 19.058 ns | 0.0813 ns | 0.0760 ns |  4.64 |    0.02 |    3 |
| ConcurrentCacheTable | 42.084 ns | 0.2406 ns | 0.2250 ns | 10.25 |    0.06 |    5 |
|           Dictionary | 11.172 ns | 0.0216 ns | 0.0180 ns |  2.72 |    0.01 |    2 |
| ConcurrentDictionary | 35.112 ns | 0.0793 ns | 0.0703 ns |  8.55 |    0.02 |    4 |
|                 Hash |  4.106 ns | 0.0088 ns | 0.0078 ns |  1.00 |    0.00 |    1 |

**After**

|               Method |      Mean |     Error |    StdDev | Ratio | RatioSD | Rank |
|--------------------- |----------:|----------:|----------:|------:|--------:|-----:|
|           CacheTable | 17.056 ns | 0.0293 ns | 0.0245 ns |  4.16 |    0.01 |    3 |
| ConcurrentCacheTable | 32.271 ns | 0.1045 ns | 0.0977 ns |  7.87 |    0.03 |    4 |
|           Dictionary | 11.169 ns | 0.0149 ns | 0.0139 ns |  2.72 |    0.01 |    2 |
| ConcurrentDictionary | 35.178 ns | 0.1235 ns | 0.1155 ns |  8.58 |    0.03 |    5 |
|                 Hash |  4.100 ns | 0.0101 ns | 0.0095 ns |  1.00 |    0.00 |    1 |